### PR TITLE
解决再次打开程序不显示其他歌单中歌曲列表问题

### DIFF
--- a/mainwid.cpp
+++ b/mainwid.cpp
@@ -2308,7 +2308,7 @@ void MainWid::changeDarkTheme()
         {
     //        qDebug()<<"mySideBar->songListWidget->count() : "<<mySideBar->songListWidget->count();
             mySideBar->musicListChangeWid[i]->musiclistcolor();
-            mySideBar->musicListChangeWid[i]->musicInfoWidget->clear();
+//            mySideBar->musicListChangeWid[i]->musicInfoWidget->clear();
     //        mySideBar->get_listmusic_information(i, playListNameList.at(i));
             mySideBar->newSongListBtn[i]->setIcon(QIcon(":/img/default/songlist_w .png"));
 
@@ -2347,7 +2347,7 @@ void MainWid::changeLightTheme()
     {
         for (int i = 0; i < playListNameList.size(); i++)
         {
-            mySideBar->musicListChangeWid[i]->musicInfoWidget->clear();
+//            mySideBar->musicListChangeWid[i]->musicInfoWidget->clear();
     //        mySideBar->get_listmusic_information(i, playListNameList.at(i));
             mySideBar->musicListChangeWid[i]->musiclistcolor();
 


### PR DESCRIPTION
解决再次打开程序不显示其他歌单中歌曲列表问题,
去掉初始化时clear操作